### PR TITLE
remove unused variable $context

### DIFF
--- a/src/cache.php
+++ b/src/cache.php
@@ -27,7 +27,7 @@ class cache
      * @param object $context Optional. A context container (e.g. \arc\lambda\Prototype) from which the
      *                        starting path is retrieved ( $context->arcPath )
      */
-    public static function create($prefix = null, $timeout = 7200, $context = null)
+    public static function create($prefix = null, $timeout = 7200)
     {
         if (!defined('ARC_CACHE_DIR')) {
             define( 'ARC_CACHE_DIR', sys_get_temp_dir().'/arc/cache' );

--- a/src/cache.php
+++ b/src/cache.php
@@ -24,8 +24,6 @@ class cache
      * defined in the system temp dir under arc/cache/.
      * @param string $prefix  Optional. A prefix name or path for subsequent cache images
      * @param mixed  $timeout Optional. Number of seconds (int) or string parseable by strtotime. Defaults to 7200.
-     * @param object $context Optional. A context container (e.g. \arc\lambda\Prototype) from which the
-     *                        starting path is retrieved ( $context->arcPath )
      */
     public static function create($prefix = null, $timeout = 7200)
     {


### PR DESCRIPTION
The other solution would be placing line 50 in a if statement checking if $context is null
